### PR TITLE
Remove binding.prys in code

### DIFF
--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -1,5 +1,4 @@
 require 'httparty'
-require 'pry'
 module Rush
 
   class Client
@@ -61,7 +60,7 @@ module Rush
       response = HTTParty.get(api_uri + 'deliveries?offset=' + offset.to_s, headers: { "Authorization" => "Bearer #{access_token}"})
       # Transforms json into a hash
       result = response.parsed_response["deliveries"].map {|p| p.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}}
-      binding.pry
+
       return result.map{|s| Delivery.new(s)}
     end
 


### PR DESCRIPTION
There are binding.pry within the client. Seems like there was some debugging going on and was committed to master. This PR removes this `binding.pry` so that people using this gem would not have their code stop executing.
