### PR TITLE
Fix `Rush::Client.get_quotes` and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 The goal of this gem is to provide a layer of abstraction for the Uber Rush API.
 For more information about the Rush API, please visit: https://developer.uber.com/docs/rush
 
-
 ## Installation
-
 
 Add this line to your application's Gemfile:
 
@@ -23,57 +21,91 @@ Or install it yourself as:
 
 ## Usage
 
-
-### Authentication
+### Configuration
 ```ruby
 Rush.configure do |config|
-  config.client_secret = "client_secret"
   config.client_id = "client_id"
+  config.client_secret = "client_secret"
   config.server_token = "server_token"
   config.sandbox = true
 end
 ```
-### Fetch deliveries
+
+### Read Access Token
+
+> You can authenticate as your application using the `client_credentials` grant type. This will create an OAuth 2.0 access token with the specified scopes. These tokens cannot be refreshed, but they can be created as many times as needed (e.g., for each server/thread or when they expire). [(more info)](https://developer.uber.com/docs/deliveries/guides/authentication#client-credentials-flow)
+
 ```ruby
-client = Rush::Client.new
-client.fetch_deliveries
+client = Rush::Client.new # Authenticates on initialize
+client.get_access_token # does not generate a new token
 ```
-### Get a quote
 
-### Order a delivery
+### Fetch Deliveries
+
+> Get a list of all deliveries, ordered chronologically by time of creation. [(more info)](https://developer.uber.com/docs/deliveries/references/api/v1-deliveries-get)
+
 ```ruby
-client = Rush::Client.new
 client.fetch_deliveries
+# => List of Delivery objects
+```
 
-location = { address: '636 w 28th street',
-             city: 'New York',
-             state: 'NY',
-             postal_code: '10014',
-             country: 'US'}
-contact = {
+### Get a Quote and Order a Delivery
+
+First, you need to setup a `Rush::PickUp` and `Rush::DropOff` with some location and contact information:
+
+```ruby
+pickup_location = { address: '636 w 28th street',
+  city: 'New York',
+  state: 'NY',
+  postal_code: '10014',
+  country: 'US'
+}
+pickup_contact = {
   first_name: 'Tester',
   last_name: 'Mctestie',
   phone: {number: '+14214214211'}
 }
 
-signature_required = false
-pickup = Rush::PickUp.new(location: location, contact: contact, signature_required: signature_required)
-dropoff = Rush::DropOff.new(location: location, contact: contact, signature_required: signature_required)
-items = [{title: 'Chocolate bar', quantity: 1, is_fragile: true}]
-client.create_delivery(items, pickup, dropoff)
-    location = { address: '64 Seabring St',
-             city: 'Brooklyn',
-             state: 'NY',
-             postal_code: '11231',
-             country: 'US'}
-    contact = {
-      first_name: 'tester',
-      last_name: 'Mctestie',
-      phone: {number: '+14214214211'}
-    }
+dropoff_location = { address: '64 Seabring St',
+  city: 'Brooklyn',
+  state: 'NY',
+  postal_code: '11231',
+  country: 'US'
+}
+dropoff_contact = {
+  first_name: 'tester dropoff',
+  last_name: 'Mctestie',
+  phone: {number: '+14214214211'}
+}
+
+pickup = Rush::PickUp.new(location: pickup_location, contact: pickup_contact, signature_required: false)
+dropoff = Rush::DropOff.new(location: dropoff_location, contact: dropoff_contact, signature_required: false)
+```
+Now, we can get a quote or create a delivery:
+
+#### Get a Quote
+> Generate a delivery quote, given a pickup and dropoff location. On-demand and scheduled delivery quotes will be returned. [(more info)](https://developer.uber.com/docs/deliveries/references/api/v1-deliveries-quote-post)
+
+```ruby
+client.get_quotes(pickup, dropoff)
+# => List of quote hashes
 ```
 
+#### Create a Delivery
 
+> The Delivery endpoint allows a delivery to be requested given the delivery information and quote ID. [(more info)](https://developer.uber.com/docs/deliveries/references/api/v1-deliveries-post)
+
+```ruby
+items = [
+    {
+      title: 'Chocolate bar',
+      quantity: 1,
+      is_fragile: true
+    }
+  ]
+client.create_delivery(items, pickup, dropoff)
+# => Delivery Hash
+```
 
 ## Development
 

--- a/bin/console
+++ b/bin/console
@@ -7,8 +7,12 @@ require "rush"
 # with your gem easier. You can also use a different console, if you like.
 
 # (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
 
-require "irb"
-IRB.start
+Rush.configure do |config|
+  config.client_id = "client_id"
+  config.client_secret = "client_secret"
+  config.sandbox = true
+end
+
+require "pry"
+Pry.start

--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -1,9 +1,7 @@
 require 'httparty'
 
 module Rush
-
   class Client
-
     OAUTH_URI = 'https://login.uber.com/oauth/v2/token'
     attr_accessor *Configuration::VALID_CONNECTION_KEYS
 
@@ -15,8 +13,8 @@ module Rush
       Configuration::VALID_CONNECTION_KEYS.each do |key|
         send("#{key}=", merged_options[key])
       end
-      get_access_token
 
+      get_access_token
     end
 
     def api_uri
@@ -53,8 +51,9 @@ module Rush
     end
 
     def get_quotes(pickup, dropoff)
-      body = {pickup: pickup, dropoff: dropoff}
-      response = HTTParty.post(api_uri + 'deliveries/quote', body: body, headers: { "Authorization" => "Bearer #{access_token}"})
+      body = {pickup: pickup.to_json, dropoff: dropoff.to_json}.to_json
+
+      HTTParty.post(api_uri + 'deliveries/quote', body: body, headers: { "Authorization" => "Bearer #{access_token}", "Content-Type" => "application/json"})
     end
 
     def fetch_deliveries(offset=0)
@@ -69,8 +68,8 @@ module Rush
       response = HTTParty.get(api_uri + 'deliveries/' + id.to_s, headers: { "Authorization" => "Bearer #{access_token}"})
       # Transforms json into a hash
       result = response.parsed_response.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
-      return Delivery.new(result)
 
+      return Delivery.new(result)
     end
   end
 end

--- a/lib/rush/drop_off.rb
+++ b/lib/rush/drop_off.rb
@@ -7,11 +7,14 @@ module Rush
         send("#{key}=", value)
       end
     end
+
     def to_json
-      return {'location'=> location,
-       'contact'=> contact,
-       'special_instructions'=> special_instructions,
-       'signature_required' => signature_required}
+      return {
+        'location' =>  location,
+        'contact'=> contact,
+        'special_instructions'=> special_instructions,
+        'signature_required' => signature_required
+      }
     end
   end
 end

--- a/lib/rush/pick_up.rb
+++ b/lib/rush/pick_up.rb
@@ -9,10 +9,12 @@ module Rush
     end
 
     def to_json
-      return {location:  location,
-       'contact'=> contact,
-       'special_instructions'=> special_instructions,
-       'signature_required' => signature_required}
+      return {
+        'location' =>  location,
+        'contact'=> contact,
+        'special_instructions'=> special_instructions,
+        'signature_required' => signature_required
+      }
     end
   end
 end

--- a/rush.gemspec
+++ b/rush.gemspec
@@ -33,5 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
+
   spec.add_dependency "httparty"
 end


### PR DESCRIPTION
- needed to have `.to_json` for both `pickup` and `dropoff` objects in `Rush::Client.get_quotes`
- updated README to include instructions for getting a quote and reading the access token
- some code cleanup
- update `bin/console` to use Pry and include config for easy testing (now you just have to copy paste app credentials when interactively testing)
