### PR TITLE
Server Tokens are not supported by UberRUSH API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Or install it yourself as:
 Rush.configure do |config|
   config.client_id = "client_id"
   config.client_secret = "client_secret"
-  config.server_token = "server_token"
   config.sandbox = true
 end
 ```

--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -25,7 +25,6 @@ module Rush
       return self if access_token
       data = {client_secret: client_secret,
               client_id: client_id,
-              server_token: server_token,
               grant_type: 'client_credentials',
               scope: sandbox ? 'delivery_sandbox' : ''
       }

--- a/lib/rush/configuration.rb
+++ b/lib/rush/configuration.rb
@@ -1,12 +1,11 @@
 module Rush
   module Configuration
-    VALID_CONNECTION_KEYS = [:client_secret, :client_id, :sandbox, :server_token, :access_token].freeze
+    VALID_CONNECTION_KEYS = [:client_secret, :client_id, :sandbox, :access_token].freeze
     DEFAULT_CLIENT_SECRET = nil
     DEFAULT_CLIENT_ID = nil
     DEFAULT_SANDBOX = true
     API_SANDBOX_URI = 'https://sandbox-api.uber.com/v1/'
     API_PRODUCTION_URI = 'https://api.uber.com/v1/'
-
 
     attr_accessor *VALID_CONNECTION_KEYS
 


### PR DESCRIPTION
Removing `server_token` references because they are ignored / not used with the UberRUSH API
