### PR TITLE
Added `client.cancel_delivery`

### DIFF
--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -72,5 +72,11 @@ module Rush
       return Delivery.new(result)
 
     end
+
+    def cancel_delivery(id)
+      response = HTTParty.post(api_uri + "deliveries/#{id}/cancel", headers: { "Authorization" => "Bearer #{access_token}"})
+
+      return response.success?
+    end
   end
 end

--- a/lib/rush/delivery.rb
+++ b/lib/rush/delivery.rb
@@ -2,12 +2,14 @@ require 'httparty'
 
 module Rush
   class Delivery
-    attr_accessor :client, :items, :pickup, :dropoff
+    attr_accessor :client, :items, :pickup, :dropoff, :status, :id
     def initialize(opts)
       @client = opts[:client]
       @items = opts[:items]
       @pickup = opts[:pickup]
       @dropoff = opts[:dropoff]
+      @status = opts[:status]
+      @id = opts[:delivery_id]
     end
 
     def quote

--- a/spec/delivery_spec.rb
+++ b/spec/delivery_spec.rb
@@ -5,11 +5,13 @@ describe Rush do
 
     describe "new" do
       it 'sets up the right values' do
-        delivery = Rush::Delivery.new(client: 1, items: 2, pickup: 3, dropoff: 4)
+        delivery = Rush::Delivery.new(client: 1, items: 2, pickup: 3, dropoff: 4, delivery_id: "abc123", status: "processing")
         expect(delivery.client).to eq 1
         expect(delivery.items).to eq 2
         expect(delivery.pickup).to eq 3
         expect(delivery.dropoff).to eq 4
+        expect(delivery.id).to eq "abc123"
+        expect(delivery.status).to eq "processing"
       end
     end
 


### PR DESCRIPTION
This enables the gem to do something like:

``` ruby
client = Rush::Client.new
client.fetch_deliveries.first.status
# => “processing”
id = client.fetch_deliveries.first.id
client.cancel_delivery(id)
# => true
```
