### PR TITLE
Set 'delivery' scope if sandbox is set to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Or install it yourself as:
 Rush.configure do |config|
   config.client_id = "client_id"
   config.client_secret = "client_secret"
-  config.server_token = "server_token"
   config.sandbox = true
 end
 ```

--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -25,7 +25,6 @@ module Rush
       return self if access_token
       data = {client_secret: client_secret,
               client_id: client_id,
-              server_token: server_token,
               grant_type: 'client_credentials',
               scope: sandbox ? 'delivery_sandbox' : ''
       }

--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -27,7 +27,7 @@ module Rush
               client_id: client_id,
               server_token: server_token,
               grant_type: 'client_credentials',
-              scope: sandbox ? 'delivery_sandbox' : ''
+              scope: sandbox ? 'delivery_sandbox' : 'delivery'
       }
       response = HTTParty.post(OAUTH_URI, body: data)
       if response.success?

--- a/lib/rush/client.rb
+++ b/lib/rush/client.rb
@@ -65,6 +65,9 @@ module Rush
 
     def find_delivery(id)
       response = HTTParty.get(api_uri + 'deliveries/' + id.to_s, headers: { "Authorization" => "Bearer #{access_token}"})
+      
+      raise(response.parsed_response) unless response.success?
+      
       # Transforms json into a hash
       result = response.parsed_response.inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
 

--- a/lib/rush/configuration.rb
+++ b/lib/rush/configuration.rb
@@ -1,12 +1,11 @@
 module Rush
   module Configuration
-    VALID_CONNECTION_KEYS = [:client_secret, :client_id, :sandbox, :server_token, :access_token].freeze
+    VALID_CONNECTION_KEYS = [:client_secret, :client_id, :sandbox, :access_token].freeze
     DEFAULT_CLIENT_SECRET = nil
     DEFAULT_CLIENT_ID = nil
     DEFAULT_SANDBOX = true
     API_SANDBOX_URI = 'https://sandbox-api.uber.com/v1/'
     API_PRODUCTION_URI = 'https://api.uber.com/v1/'
-
 
     attr_accessor *VALID_CONNECTION_KEYS
 

--- a/lib/rush/version.rb
+++ b/lib/rush/version.rb
@@ -1,3 +1,3 @@
 module Rush
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
This fixes the error `RuntimeError: Could not retrieve access token: {"error": "invalid_scope"}`